### PR TITLE
Improve documentation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,40 @@
 # Trading Bot
 
-This project provides a modular algorithmic trading bot. The code has been
-refactored into dedicated modules for data access, order management and
-strategy logic to improve readability and maintainability. It targets a
-Windows environment running Python 3.12.
+This repository contains a fully modular algorithmic trading bot aimed at
+automating equity trades.  Each piece of functionality – from data retrieval to
+order execution – lives in a small, well documented module.  The code targets
+Python 3.12 and has minimal external dependencies, making it suitable for local
+experimentation or further extension.
 
-## Project Structure
+## Features
 
-- `config.py` – loads environment variables and defines common constants.
-- `models.py` – dataclasses and enums that describe orders and positions.
-- `data_access.py` – database layer for persisting orders and positions.
-- `order_management.py` – routines for placing and managing orders.
-- `brokers.py` – lightweight abstractions for broker integrations.
-- `data_providers.py` – pluggable market data provider interfaces, including
-  real-time streaming via the Yahoo Finance API.
-- `strategy.py` – trading strategy, indicators and bot orchestration.
-- `main.py` – entry point that wires everything together.
+- Pulls historical and real‑time market data from Yahoo Finance or Alpha Vantage
+- Persists orders, positions and analytics snapshots to a local SQLite database
+- Scores symbols using a rich set of technical indicators and market regime
+  filters
+- Places bracket orders and manages stops through a pluggable broker interface
+- Optional push notifications via the Pushover service
+
+## Repository Layout
+
+The project is intentionally split into small modules to keep concerns isolated:
+
+| Module | Description |
+| ------ | ----------- |
+| `config.py` | Loads environment variables and defines global constants |
+| `models.py` | Dataclasses and enums representing orders and positions |
+| `data_access.py` | SQLite persistence for orders, positions and analytics |
+| `order_management.py` | High level order submission and modification logic |
+| `brokers.py` | Lightweight abstractions for broker integrations (IBKR) |
+| `data_providers.py` | Interfaces for external market data sources |
+| `strategy.py` | Trading strategy, indicator helpers and `TradingBot` orchestration |
+| `alerts.py` | Convenience wrapper for Pushover notifications |
+| `main.py` | Command line entry point to run the bot |
 
 ## Configuration
 
-Runtime configuration is provided through a `.env` file. The following
-parameters are supported:
+Runtime configuration is supplied through a `.env` file located in the project
+root.  The following variables are recognised:
 
 ```
 DB_PATH=trading_bot.db
@@ -36,21 +50,33 @@ DEBUG=0
 SP100_CSV=
 ```
 
-`PUSHOVER_USER` and `PUSHOVER_TOKEN` enable optional push notifications via
-the [Pushover](https://pushover.net/) service. Set `DEBUG` to ``1`` for
-verbose logging. `SP100_CSV` should point to a CSV file containing the S&P
-100 constituents. Additional variables can be added as needed. Defaults are
-provided when the variables are absent.
+`PUSHOVER_USER` and `PUSHOVER_TOKEN` enable optional push notifications via the
+[Pushover](https://pushover.net/) service.  Set `DEBUG` to ``1`` for verbose
+logging.  `SP100_CSV` should point to a CSV file containing the S&P 100
+constituents.  Defaults are provided when the variables are absent.
 
-## Development
+## Installation
 
 Create a Python 3.12 virtual environment and install dependencies:
 
 ```
-pip install -r requirements.txt  # if available
+pip install -r requirements.txt
 ```
 
-Run the test suite:
+## Usage
+
+Populate a `.env` file with the desired configuration, then run the bot:
+
+```
+python main.py
+```
+
+On start-up the bot fetches account details, loads any persisted positions and
+evaluates the trading universe defined by `SP100_CSV`.
+
+## Development
+
+Run the test suite to validate changes:
 
 ```
 pytest -q
@@ -58,11 +84,9 @@ pytest -q
 
 ## Notes
 
-The bot integrates with real broker APIs and market data providers. By
-default it retrieves market data from Yahoo Finance, while IBKR handles
-account management and order execution. The included `ibkr_client.py`
-demonstrates how to request historical data and submit basic orders while
-respecting their pacing limitations. Upon startup the bot
-logs the current IBKR cash balance, buying power and any open positions
-loaded from the local database.
+The bot integrates with real broker APIs and market data providers.  By default
+it retrieves market data from Yahoo Finance while IBKR handles account
+management and order execution.  The included `ibkr_client.py` demonstrates how
+to request historical data and submit basic orders while respecting IBKR pacing
+limitations.
 

--- a/alerts.py
+++ b/alerts.py
@@ -1,3 +1,5 @@
+"""Utility helpers for sending notifications to external services."""
+
 import logging
 
 import requests

--- a/config.py
+++ b/config.py
@@ -1,3 +1,11 @@
+"""Centralized configuration and environment settings for the trading bot.
+
+This module loads environment variables from a ``.env`` file and exposes
+constants used throughout the system such as database paths, logging
+locations and market session times.  Only lightweight logic lives here so the
+rest of the codebase can import configuration values without side effects.
+"""
+
 import os
 from datetime import time
 import pytz

--- a/data_access.py
+++ b/data_access.py
@@ -1,3 +1,11 @@
+"""Persistence layer for orders, positions and analytics data.
+
+The :class:`DataManager` encapsulates all SQLite database interactions,
+providing simple methods to store and retrieve the bot's state.  Keeping the
+SQL logic in a dedicated module makes it easier to swap out the underlying
+storage backend in the future.
+"""
+
 import json
 import logging
 import sqlite3
@@ -9,6 +17,8 @@ from config import DB_PATH
 
 
 class DataManager:
+    """Thin wrapper around SQLite for persisting bot state."""
+
     def __init__(self, db_path: str = DB_PATH):
         self.db_path = db_path
         self._init_db()

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+"""Executable entry point for running the trading bot locally."""
+
 import logging
 
 from alerts import send_alert

--- a/models.py
+++ b/models.py
@@ -1,3 +1,11 @@
+"""Core domain models and enumerations used by the trading bot.
+
+The module defines lightweight :class:`dataclasses.dataclass` and
+``Enum`` types that describe orders, positions and market regimes.  These
+structures are intentionally simple and free of behaviour so they can be
+shared between modules without creating circular dependencies.
+"""
+
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -7,12 +15,16 @@ from config import EASTERN_TZ
 
 
 class MarketRegime(Enum):
+    """High level classification of prevailing market conditions."""
+
     TRENDING = "TR"
     RANGING = "RG"
     RISK_OFF = "RO"
 
 
 class OrderStatus(Enum):
+    """Lifecycle states for submitted orders."""
+
     PENDING_NEW = "PENDING_NEW"
     LIVE = "LIVE"
     PARTIALLY_FILLED = "PARTIALLY_FILLED"
@@ -23,12 +35,16 @@ class OrderStatus(Enum):
 
 
 class OrderType(Enum):
+    """Supported order types."""
+
     LMT = "LMT"
     STP = "STP"
     TRAIL = "TRAIL"
 
 
 class PositionStatus(Enum):
+    """State machine representing a trade's lifecycle."""
+
     INIT = "INIT"
     ARMED = "ARMED"
     FILLED = "FILLED"
@@ -41,6 +57,8 @@ class PositionStatus(Enum):
 
 @dataclass
 class Order:
+    """Representation of an order submitted to a broker."""
+
     order_id: str
     symbol: str
     order_type: OrderType
@@ -56,7 +74,9 @@ class Order:
     child_orders: List[str] = None
     timestamp: datetime = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
+        """Ensure optional fields have sensible defaults."""
+
         if self.child_orders is None:
             self.child_orders = []
         if self.timestamp is None:
@@ -65,6 +85,8 @@ class Order:
 
 @dataclass
 class Position:
+    """Represents an open or closed trading position."""
+
     position_id: str
     symbol: str
     entry_time: datetime
@@ -79,6 +101,8 @@ class Position:
     score_components: Dict = None
     risk_per_share: float = 0.0
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
+        """Populate mutable default fields after initialization."""
+
         if self.score_components is None:
             self.score_components = {}

--- a/order_management.py
+++ b/order_management.py
@@ -1,3 +1,5 @@
+"""High-level routines for creating and managing trading orders."""
+
 import logging
 from datetime import datetime
 from typing import Dict, List
@@ -5,7 +7,10 @@ from typing import Dict, List
 from models import Order, OrderType, OrderStatus
 from brokers import BrokerAPI
 
+
 class OrderManager:
+    """Orchestrates order submission and modification logic."""
+
     def __init__(self, data_manager, broker: BrokerAPI | None = None):
         self.orders: Dict[str, Order] = {}
         self.position_orders: Dict[str, List[str]] = {}

--- a/strategy.py
+++ b/strategy.py
@@ -1,3 +1,5 @@
+"""Trading strategy implementation and supporting analytics utilities."""
+
 import logging
 import csv
 import os
@@ -20,7 +22,10 @@ from ibkr_client import IBKRClient
 from data_providers import YahooDataProvider
 from brokers import IBKRBroker
 
+
 class Indicators:
+    """Collection of technical indicator calculation helpers."""
+
     @staticmethod
     def calculate_sma(data: pd.Series, window: int) -> pd.Series:
         return data.rolling(window=window).mean()
@@ -101,6 +106,8 @@ class Indicators:
         return obv
 
 class DataRollUp:
+    """Utilities for aggregating hourly bars into 4H session-aligned bars."""
+
     def __init__(self):
         self.valid_4h_start_times = FOUR_HOUR_TIMES
         
@@ -160,6 +167,8 @@ class DataRollUp:
         }
 
 class SupportLevelAnalyzer:
+    """Determine the nearest technical support level for a symbol."""
+
     def __init__(self):
         self.support_priority = [
             'validated_trendline',
@@ -273,6 +282,8 @@ class SupportLevelAnalyzer:
                 support_info['distance_pct'] <= max_distance_pct)
 
 class ExitConfirmation:
+    """Verify that multiple indicators agree before exiting a trade."""
+
     def __init__(self):
         self.required_signals = ['supertrend_bearish', 'macd_bear_cross']
     
@@ -324,6 +335,8 @@ class ExitConfirmation:
                 candle.get('macd_line', 0) < candle.get('macd_signal', 0))
 
 class ScoringEngine:
+    """Combine indicator readings into aggregate entry and exit scores."""
+
     def __init__(self):
         self.logger = logging.getLogger(f"{__name__}.ScoringEngine")
     
@@ -565,6 +578,8 @@ class ScoringEngine:
         return score, confirmation
 
 class RegimeDetector:
+    """Infer the prevailing market regime using SPY and VIX data."""
+
     def __init__(self):
         self.logger = logging.getLogger(f"{__name__}.RegimeDetector")
     
@@ -633,6 +648,8 @@ class RegimeDetector:
         return MarketRegime.RANGING
 
 class SentimentAnalyzer:
+    """Fetch external sentiment metrics to gate trading signals."""
+
     def __init__(self):
         self.logger = logging.getLogger(f"{__name__}.SentimentAnalyzer")
     
@@ -698,6 +715,8 @@ class SentimentAnalyzer:
         return entry_score, {"fg_index": fg_index, "news_sentiment": news_sentiment, "action": "adjusted"}
 
 class TradingBot:
+    """High-level orchestrator coordinating data, scoring and orders."""
+
     def __init__(self, broker: IBKRBroker | None = None, data_provider: YahooDataProvider | None = None):
         self.logger = logging.getLogger(f"{__name__}.TradingBot")
 


### PR DESCRIPTION
## Summary
- add module and class documentation across core modules and strategy components
- expand README with project features, layout, installation and usage instructions

## Testing
- `python -m py_compile config.py models.py data_access.py order_management.py strategy.py alerts.py main.py brokers.py data_providers.py ibkr_client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acc16741848331ae76badebd95d652