### PR TITLE
Disable unsupported eTradeOnly flag for IBKR orders

### DIFF
--- a/brokers.py
+++ b/brokers.py
@@ -41,6 +41,13 @@ class IBKRBroker(BrokerAPI):
         contract = stock_contract(order.symbol)
         ib_order = IBOrder()
         ib_order.action = order.side
+        # Explicitly disable unsupported broker attributes.
+        # Some IBKR API versions default ``eTradeOnly`` to ``True``,
+        # which can trigger error 10268 ("'EtradeOnly' order attribute is not supported")
+        # when the field is sent to the server.  Setting it to ``False`` prevents
+        # the attribute from being transmitted.
+        if hasattr(ib_order, "eTradeOnly"):
+            ib_order.eTradeOnly = False
 
         # Ensure we don't submit fractional share sizes which older API
         # versions cannot handle.  Trim to an integer and log the adjustment

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ def _validate_env() -> None:
 
 def main():
     """Entry point for running the trading bot."""
+    bot = None
     try:
         mode = None
         if len(sys.argv) > 1:
@@ -70,11 +71,13 @@ def main():
         _validate_env()
         bot = TradingBot()
         bot.run_hourly()  # Run one full cycle before returning
-        return bot  # Wrap in a scheduler for continuous execution
     except Exception as exc:  # pragma: no cover - integration dependent
         logging.exception("Fatal error starting trading bot")
         send_alert(f"Trading bot error: {exc}")
         raise
+    finally:
+        if bot:
+            bot.shutdown()
 
 
 if __name__ == "__main__":

--- a/strategy.py
+++ b/strategy.py
@@ -900,6 +900,16 @@ class TradingBot:
                 )
         else:
             self.logger.info("No open positions loaded")
+
+    def shutdown(self) -> None:
+        """Release external resources such as the IBKR client connection."""
+        if self.ibkr:
+            try:  # pragma: no cover - network dependent
+                self.ibkr.disconnect()
+            except Exception as e:  # pragma: no cover - network dependent
+                self.logger.warning(f"Error disconnecting IBKR client: {e}")
+            finally:
+                self.ibkr = None
     
     def run_hourly(self):
         """Main hourly execution loop"""


### PR DESCRIPTION
## Summary
- avoid IBKR error 10268 by clearing unsupported `eTradeOnly` order attribute
- ensure IBKR client disconnects after runs so the bot exits cleanly

## Testing
- `python -m py_compile brokers.py main.py strategy.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b85e7981248331b91289682cb20e81